### PR TITLE
Save `CameraPickerItems`s

### DIFF
--- a/Sources/CameraPicker/CameraPicker.swift
+++ b/Sources/CameraPicker/CameraPicker.swift
@@ -16,7 +16,7 @@ public extension CameraPicker {
 
 public struct CameraPicker<Label>: View where Label: View {
     let label: Label
-    @Binding var selection: [CameraPickerItem]
+    @Binding var selection: [any CameraPickerItem]
     @State private var imagePickerControllerError: LocalizedError?
     @State private var showingCamera = false
 
@@ -27,7 +27,7 @@ public struct CameraPicker<Label>: View where Label: View {
     let flashMode: FlashMode
 
     public init(
-        selection: Binding<[CameraPickerItem]>,
+        selection: Binding<[any CameraPickerItem]>,
         allowsEditing: Bool = false,
         preferredMediaTypes: Set<CameraPickerMediaType> = [.image],
         cameraDevice: Device = .rear,
@@ -77,9 +77,9 @@ public struct CameraPicker<Label>: View where Label: View {
 
 extension CameraPicker {
     private static func arrayBindingFrom(
-        optionalBinding: Binding<CameraPickerItem?>
-    ) -> Binding<[CameraPickerItem]> {
-        Binding<[CameraPickerItem]> {
+        optionalBinding: Binding<(any CameraPickerItem)?>
+    ) -> Binding<[any CameraPickerItem]> {
+        Binding<[any CameraPickerItem]> {
             if let item = optionalBinding.wrappedValue {
                 return [item]
             } else {
@@ -95,7 +95,7 @@ extension CameraPicker {
     }
 
     public init(
-        selection: Binding<CameraPickerItem?>,
+        selection: Binding<(any CameraPickerItem)?>,
         allowsEditing: Bool = false,
         preferredMediaTypes: Set<CameraPickerMediaType> = [.image],
         cameraDevice: Device = .rear,
@@ -118,7 +118,7 @@ extension CameraPicker {
 extension CameraPicker where Label == Text {
     public init(
         _ titleKey: LocalizedStringKey,
-        selection: Binding<CameraPickerItem?>,
+        selection: Binding<(any CameraPickerItem)?>,
         allowsEditing: Bool = false,
         preferredMediaTypes: Set<CameraPickerMediaType> = [.image],
         cameraDevice: Device = .rear,
@@ -139,7 +139,7 @@ extension CameraPicker where Label == Text {
 
     public init<S>(
         _ title: S,
-        selection: Binding<CameraPickerItem?>,
+        selection: Binding<(any CameraPickerItem)?>,
         allowsEditing: Bool = false,
         preferredMediaTypes: Set<CameraPickerMediaType> = [.image],
         cameraDevice: Device = .rear,
@@ -160,7 +160,7 @@ extension CameraPicker where Label == Text {
 
     public init(
         _ titleKey: LocalizedStringKey,
-        selection: Binding<[CameraPickerItem]>,
+        selection: Binding<[any CameraPickerItem]>,
         allowsEditing: Bool = false,
         preferredMediaTypes: Set<CameraPickerMediaType> = [.image],
         cameraDevice: Device = .rear,
@@ -181,7 +181,7 @@ extension CameraPicker where Label == Text {
 
     public init<S>(
         _ title: S,
-        selection: Binding<[CameraPickerItem]>,
+        selection: Binding<[any CameraPickerItem]>,
         allowsEditing: Bool = false,
         preferredMediaTypes: Set<CameraPickerMediaType> = [.image],
         cameraDevice: Device = .rear,

--- a/Sources/CameraPicker/CameraPickerItem.swift
+++ b/Sources/CameraPicker/CameraPickerItem.swift
@@ -8,13 +8,22 @@
 import SwiftUI
 import AVFoundation
 
-public enum CameraPickerItem {
-    case image(Image)
-    case video(AVPlayer)
+public protocol CameraPickerItem: Identifiable where ID == UUID {
+    associatedtype MediaType
+
+    var mediaType: MediaType { get }
+    var id: Self.ID { get }
+
+    func save() async throws
 }
 
-extension CameraPickerItem: Identifiable {
-    public var id: UUID {
-        UUID()
+public struct ImageCameraPickerItem: CameraPickerItem {
+    public let id = UUID()
+    public var mediaType: Image
+    var underlyingMediaType: UIImage
+
+    public func save() async throws {
+        let mediaSaver = MediaSaver()
+        try await mediaSaver.save(underlyingMediaType)
     }
 }

--- a/Sources/CameraPicker/ForEach+CameraPickerItem.swift
+++ b/Sources/CameraPicker/ForEach+CameraPickerItem.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-public extension ForEach where ID == UUID, Content : View, Data.Element == any CameraPickerItem {
+public extension ForEach where ID == UUID, Content: View, Data.Element == any CameraPickerItem {
     init(_ data: Data, @ViewBuilder content: @escaping (any CameraPickerItem) -> Content) {
         self.init(data, id: \.id, content: content)
     }

--- a/Sources/CameraPicker/ForEach+CameraPickerItem.swift
+++ b/Sources/CameraPicker/ForEach+CameraPickerItem.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  
+//
+//  Created by Abdulaziz Alobaili on 02/06/2023.
+//
+
+import SwiftUI
+
+public extension ForEach where ID == UUID, Content : View, Data.Element == any CameraPickerItem {
+    init(_ data: Data, @ViewBuilder content: @escaping (any CameraPickerItem) -> Content) {
+        self.init(data, id: \.id, content: content)
+    }
+}

--- a/Sources/CameraPicker/MediaSaver.swift
+++ b/Sources/CameraPicker/MediaSaver.swift
@@ -1,0 +1,42 @@
+//
+//  MediaSaver.swift
+//  
+//
+//  Created by Abdulaziz Alobaili on 02/06/2023.
+//
+
+import UIKit
+
+final class MediaSaver: NSObject {
+    typealias SaveImageContinuation = CheckedContinuation<Void, Error>
+
+    var continuation: SaveImageContinuation?
+
+    func save(_ image: UIImage) async throws {
+        try await withCheckedThrowingContinuation { (continuation: SaveImageContinuation) in
+            self.continuation = continuation
+
+            UIImageWriteToSavedPhotosAlbum(
+                image,
+                self,
+                #selector(image(_:didFinishSavingWithError:contextInfo:)),
+                nil
+            )
+        }
+    }
+
+    @objc func image(
+        _ image: UIImage,
+        didFinishSavingWithError error: Error?,
+        contextInfo: UnsafeRawPointer
+    ) {
+        if let error {
+            continuation?.resume(throwing: error)
+            return
+        } else {
+            continuation?.resume()
+        }
+
+        continuation = nil
+    }
+}

--- a/Sources/CameraPicker/UIImagePickerControllerRepresentation.swift
+++ b/Sources/CameraPicker/UIImagePickerControllerRepresentation.swift
@@ -28,7 +28,7 @@ public enum CameraPickerMediaType: Hashable {
 }
 
 struct UIImagePickerControllerRepresentation: UIViewControllerRepresentable {
-    @Binding var selection: [CameraPickerItem]
+    @Binding var selection: [any CameraPickerItem]
     @Binding var error: LocalizedError?
     let allowsEditing: Bool
     let preferredMediaTypes: Set<CameraPickerMediaType>
@@ -92,13 +92,20 @@ extension UIImagePickerControllerRepresentation {
             // TODO: Handle movies.
 
             if let editedImage = info[.editedImage] as? UIImage {
-                parent.selection = [.image(Image(uiImage: editedImage))]
+                let image = Image(uiImage: editedImage)
+                let imageCameraPickerItem = ImageCameraPickerItem(
+                    mediaType: image,
+                    underlyingMediaType: editedImage
+                )
+                parent.selection = [imageCameraPickerItem]
                 picker.dismiss(animated: true)
                 return
             }
 
             let originalImage = info[.originalImage] as! UIImage
-            parent.selection = [.image(Image(uiImage: originalImage))]
+            let image = Image(uiImage: originalImage)
+            let imageCameraPickerItem = ImageCameraPickerItem(mediaType: image, underlyingMediaType: originalImage)
+            parent.selection = [imageCameraPickerItem]
             picker.dismiss(animated: true)
         }
 


### PR DESCRIPTION
This PR introduces the `save` method on `CameraPickerItem`, which allows for saving the picked item into the Photos app.